### PR TITLE
Adding rotor status functionality to web UI

### DIFF
--- a/satnogsclient/web/static/js/satnogs-status.js
+++ b/satnogsclient/web/static/js/satnogs-status.js
@@ -36,6 +36,7 @@ function update_observations(data,param) {
     var json_data = data;
     var current_obs = json_data['observation']['current'];
     var scheduled_obs = json_data['observation']['scheduled'];
+    var rotor_status = json_data['observation']['rotor'];
     var tle1_current = current_obs["tle1"].split(' ');
     var tle2_current = current_obs["tle2"].split(' ');
 
@@ -89,6 +90,15 @@ function update_observations(data,param) {
     var tr = "<tr><td colspan='4'>No observations scheduled</td></tr>";
     $('#scheduled-observation-table').append(tr);
   }
+
+  //Update rotor status
+    if (rotor_status["status"] === "OK") {
+      jQuery("#rotor-status").removeClass("label-danger").addClass("label-success");
+      document.getElementById("rotor-az").innerHTML = rotor_status['azimuth'];
+      document.getElementById("rotor-el").innerHTML = rotor_status['elevation'];
+    } else {
+      jQuery("#rotor-status").removeClass("label-success").addClass("label-danger");
+    }
 }
 
 function query_status_info(JSONData, localMode, url, param) {

--- a/satnogsclient/web/templates/status.j2
+++ b/satnogsclient/web/templates/status.j2
@@ -16,13 +16,13 @@
 	  		  	<span class="label label-success" id="internet-connection">Internet</span>
 	  		  </div>
 	  		  <div class="col-xs-6 col-sm-3">
-	  	    	<span class="label label-success">SatNogs client</span>
+	  	    	<span class="label label-success" id="client-status">SatNogs client</span>
 	  		  </div>
 	  		  <div class="col-xs-6 col-sm-3">
-	  		  	<span class="label label-success">SDR</span>
+	  		  	<span class="label label-success" id="sdr-status">SDR</span>
 	  	      </div>
 	  	      <div class="col-xs-6 col-sm-3">
-	  	    	<span class="label label-danger">Rotor</span>
+	  	    	<span class="label label-danger" id="rotor-status">Rotor</span>
 	  	      </div>
 	      </div>
       </div>
@@ -33,9 +33,9 @@
   	  </div>
   	  <div class="panel-body row">
         <div class="col-xs-4">
-          <div class="col-xs-6">Azimuth:</div> <div class="col-xs-4">NA</div>
-          <div class="col-xs-6">Elevation:</div> <div class="col-xs-4">NA</div>
-          <div class="col-xs-6">Frequency:</div> <div class="col-xs-4">NA</div>
+          <div class="col-xs-6">Azimuth:</div> <div class="col-xs-4" id="rotor-az">NA</div>
+          <div class="col-xs-6">Elevation:</div> <div class="col-xs-4" id="rotor-el">NA</div>
+          <div class="col-xs-6">Frequency:</div> <div class="col-xs-4" id="frequency">NA</div>
         </div>
         <div class="col-xs-6">
         	<div class="circle">


### PR DESCRIPTION
added code to query the rotor AZ/EL (via hamlib and the configured
ROT_IP and ROT_PORT). If successful then the status turns green
and the AZ/EL of the ground station is updated. If anything fails
along the way (port unavailable, reponse is not the float we
expect, etc) then the AZ/EL is reset to NA and the status turns
red.
